### PR TITLE
Direction Step Template Update Icon

### DIFF
--- a/app/assets/javascripts/divvy-app.coffee
+++ b/app/assets/javascripts/divvy-app.coffee
@@ -15,6 +15,16 @@ divvyApp
         longitude: -87.648056
       zoom: 14
 
+    # Maneuvers almost always end in the word we need to apply the
+    # correct arrow icon class. This splits the string at the hyphen(s)
+    # and returns it if it is 'left' or 'right' since that's
+    # all that's supported for now.
+    $scope.maneuverToIcon = (maneuver) ->
+      maneuverSplit     = maneuver.split '-'
+      maneuverLastWord  = maneuverSplit[maneuverSplit.length - 1]
+      if maneuverLastWord == 'left' or maneuverLastWord == 'right'
+        maneuverLastWord
+
     $scope.clickToggleResults = (e) ->
       if !$scope.areResultsShowing
         Divvy.addLoadingCursor()

--- a/app/assets/stylesheets/sections/_sidebar.sass
+++ b/app/assets/stylesheets/sections/_sidebar.sass
@@ -215,6 +215,9 @@ $direction-left-width : 28px
   +transform(translateX(-50%) translateY(-50%))
   text-align: center
 
+  > div:nth-child(2)
+    margin-top: 5px
+
 .direction-right
   margin-left: $direction-left-width
   padding: ($padding * 2) $padding

--- a/app/views/application/index.haml
+++ b/app/views/application/index.haml
@@ -57,8 +57,7 @@
                 .direction-left
                   .direction-left-centered
                     .mdi-maps-directions-walk
-                    %span S
-                    .fa.fa-arrow-down
+                    .fa{ng_if: "step.maneuver", ng_class: "'fa-arrow-' + maneuverToIcon(step.maneuver)"}
                 .direction-right
                   %div{ng_bind_html: "step.html_instructions"}
                   %span {{step.duration.text}} ({{step.distance.text}})
@@ -75,8 +74,7 @@
                 .direction-left
                   .direction-left-centered
                     .mdi-maps-directions-bike
-                    %span W
-                    .fa.fa-arrow-right
+                    .fa{ng_if: "step.maneuver", ng_class: "'fa-arrow-' + maneuverToIcon(step.maneuver)"}
                 .direction-right
                   %div{ng_bind_html: "step.html_instructions"}
                   %span {{step.duration.text}} ({{step.distance.text}})
@@ -93,8 +91,7 @@
                 .direction-left
                   .direction-left-centered
                     .mdi-maps-directions-walk
-                    %span S
-                    .fa.fa-arrow-down
+                    .fa{ng_if: "step.maneuver", ng_class: "'fa-arrow-' + maneuverToIcon(step.maneuver)"}
                 .direction-right
                   %div{ng_bind_html: "step.html_instructions"}
                   %span {{step.duration.text}} ({{step.distance.text}})


### PR DESCRIPTION
- Maneuvers almost always end in the word we need to apply the correct arrow icon class. This splits the string at the hyphen(s) and returns it if it is 'left' or 'right' since that's all that's supported for now.
- closes #10
